### PR TITLE
Fixed the confirmation function calling incorrectly the `Message.print` method

### DIFF
--- a/src/blasmodcli/view/confirmation.py
+++ b/src/blasmodcli/view/confirmation.py
@@ -1,10 +1,10 @@
 from blasmodcli.exceptions import UserCancelException
 from blasmodcli.utils import Color
-from blasmodcli.utils.message import Message
+from blasmodcli.utils.message import ArrowStyle, Message
 
 
 def confirmation(message: str, default: bool = True):
-    Message.print(Color.YELLOW, message, nl=False)
+    Message.print(ArrowStyle.THICK, Color.YELLOW, message, nl=False)
     if default:
         string = "Y/n"
     else:

--- a/src/blasmodcli/view/counter.py
+++ b/src/blasmodcli/view/counter.py
@@ -1,5 +1,5 @@
 from blasmodcli.utils import Color
-from blasmodcli.utils.message import Message
+from blasmodcli.utils.message import Message, ArrowStyle
 
 
 class Counter:
@@ -22,6 +22,6 @@ class Counter:
     def print(self):
         color = Color.GREEN if self.finished else Color.YELLOW
         print(end="\r")
-        Message.print(color, f"{self.message}... {color.fmt(self)}", nl=False)
+        Message.print(ArrowStyle.THICK, color, f"{self.message}... {color.fmt(self)}", nl=False)
         if self.finished:
             print(flush=True)


### PR DESCRIPTION
It turns out this is simply a call to `Message.print` that wasn't changed when the `arrow` parameter was added, both in the `confirmation` function and in the `Counter` class.

This has been resolved.