### PR TITLE
Fix for the `backup` command save location

### DIFF
--- a/src/blasmodcli/controller/game/backup.py
+++ b/src/blasmodcli/controller/game/backup.py
@@ -25,6 +25,6 @@ class Backup(GameCommandGroup):
         Message.info("Backing up saves data...")
         destination = self.get_final_destination()
 
-        make_archive(str(self.destination), "zip", self.game.saves_directory.expanduser().resolve())
+        make_archive(str(destination), "zip", self.game.saves_directory.expanduser().resolve())
         Message.success(f"Saves data backed up at '{destination}'!")
         return 0


### PR DESCRIPTION
This fixes the issue where the `backup` command displays an incorrect location for the archive.

It turns out it wasn't the location displayed that is wrong, but the location where the archive is saved to by the tool.