### PR TITLE
Fixed a minor bug in the `backup` command and promoted the version from Beta to Release Candidate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blasmodcli"
-version = "1.0.0-beta.4"
+version = "1.0.0-rc.1"
 authors = [ { name = "salamint", email = "salamint@proton.me" } ]
 description = "A tool to simplify the installation and management of mods for Blasphemous and Blasphemous II on Linux."
 readme = "README.md"

--- a/src/blasmodcli/controller/game/backup.py
+++ b/src/blasmodcli/controller/game/backup.py
@@ -25,6 +25,6 @@ class Backup(GameCommandGroup):
         Message.info("Backing up saves data...")
         destination = self.get_final_destination()
 
-        make_archive(str(self.destination), "zip", self.game.saves_directory.expanduser().resolve())
+        make_archive(str(destination), "zip", self.game.saves_directory.expanduser().resolve())
         Message.success(f"Saves data backed up at '{destination}'!")
         return 0


### PR DESCRIPTION
This fixes one last bug in the `backup` command. Now that the tool is considered "relatively stable", the version suffix has been changed from `beta` to `rc` for Release Candidate.