### PR TITLE
fix: Corrected a few annotations causing errors

### DIFF
--- a/src/blasmodcli/repositories/filesystems/filesystem.py
+++ b/src/blasmodcli/repositories/filesystems/filesystem.py
@@ -28,7 +28,7 @@ class FileSystemRepository(IRepository[Path]):
             files.append(entry)
         return files
 
-    def get_all_entries(self) -> Generator[Entry]:
+    def get_all_entries(self) -> 'Generator[Entry, None, None]':
         for file in self.get_all():
             entry = self.entry(file)
             if entry is not None:
@@ -57,7 +57,7 @@ class FileSystemRepository(IRepository[Path]):
             versions.append(entry.version)
         return versions
 
-    def get_entries_for(self, mod: Mod, version: Version | None = None) -> Generator[Entry]:
+    def get_entries_for(self, mod: Mod, version: Version | None = None) -> 'Generator[Entry, None, None]':
         for file in self.get_files_for(mod, version):
             entry = self.entry(file)
             if entry is not None:
@@ -69,7 +69,7 @@ class FileSystemRepository(IRepository[Path]):
             return None
         return self.entry(file)
 
-    def get_files_for(self, mod: Mod, version: Version | None = None) -> Generator[Path]:
+    def get_files_for(self, mod: Mod, version: Version | None = None) -> 'Generator[Path, None, None]':
         for file in self.directory.glob(self.filename(mod, version)):
             if file.is_file():
                 yield file

--- a/src/blasmodcli/utils/config/directory.py
+++ b/src/blasmodcli/utils/config/directory.py
@@ -26,7 +26,7 @@ class ConfigurationDirectory(ABC, Generic[T]):
         except KeyError:
             raise MissingFieldException(self.current_file, section_name, field_name)
 
-    def files(self) -> Generator[Path]:
+    def files(self) -> 'Generator[Path, None, None]':
         for entry in self.directory.rglob("*.toml"):
             if entry.is_file():
                 yield entry

--- a/src/blasmodcli/utils/parsing/meta_parser.py
+++ b/src/blasmodcli/utils/parsing/meta_parser.py
@@ -1,10 +1,10 @@
 from abc import ABCMeta
-from typing import Any, Self
+from typing import Any
 
 
 class MetaModListParser(ABCMeta):
 
-    _parsers: dict[str, Self] = {}
+    _parsers: dict[str, 'MetaModListParser'] = {}
 
     def __new__(cls, name: str, bases: tuple[type], dct: dict[str, Any]):
         instance = super().__new__(cls, name, bases, dct)

--- a/src/blasmodcli/utils/parsing/official_parser.py
+++ b/src/blasmodcli/utils/parsing/official_parser.py
@@ -6,6 +6,7 @@ from typing import Generator
 
 from blasmodcli.exceptions.utils import NameConversionError
 from blasmodcli.model import Authorship, Mod, Source, Version
+from blasmodcli.utils import logger
 from blasmodcli.utils.parsing.parser import ModListParser, Object
 from blasmodcli.view import DateFormat
 
@@ -14,13 +15,15 @@ AUTHORS_SEPARATOR = " && "
 
 async def fetch_latest_version(session: ClientSession, repository: str) -> Version:
     url = f"{repository}/releases/latest"
+    logger.debug(f"Fetching mod URL {url}...")
     async with session.get(url) as response:
         response.raise_for_status()
         version_string = response.url.parts[-1]
+        logger.debug(f"Mod URL {url} returned {response.url}")
         return Version.from_tag(version_string)
 
 
-def parse_authors(string: str) -> Generator[str]:
+def parse_authors(string: str) -> 'Generator[str, None, None]':
     with_separators = string.replace(", && ", AUTHORS_SEPARATOR).replace(", ", AUTHORS_SEPARATOR)
     for name in with_separators.split(AUTHORS_SEPARATOR):
         yield name.strip()
@@ -60,7 +63,7 @@ class OfficialModListParser(ModListParser):
         self.all_data = data
         self.total = len(self.all_data)
 
-    def data(self) -> Generator[Object]:
+    def data(self) -> 'Generator[Object, None, None]':
         for i, data in enumerate(self.all_data):
             if not isinstance(data, dict):
                 raise TypeError(f"The value at index {i} is of type {type(data)} and not an object.")

--- a/src/blasmodcli/utils/parsing/parser.py
+++ b/src/blasmodcli/utils/parsing/parser.py
@@ -21,7 +21,7 @@ class ModListParser(ABC, metaclass=MetaModListParser):
             mods.append(mod)
 
     @abstractmethod
-    def data(self) -> Generator[Object]:
+    def data(self) -> 'Generator[Object, None, None]':
         pass
 
     @abstractmethod


### PR DESCRIPTION
This puts the type annotations in strings instead, to force Python to not execute them as runtime if they contain errors, and used the recommended syntax for Python 3.12 anyway just in case.